### PR TITLE
Small fixes

### DIFF
--- a/kantek/plugins/autobahn/automatic/polizei.py
+++ b/kantek/plugins/autobahn/automatic/polizei.py
@@ -282,9 +282,10 @@ async def _check_message(event):  # pylint: disable = R0911
             if result:
                 return db.blacklists.channel.hex_type, result.index
 
-    for string in await db.blacklists.string.get_all():
-        if string.value in msg.raw_text and not string.retired:
-            return db.blacklists.string.hex_type, string.index
+    if msg.raw_text:
+        for string in await db.blacklists.string.get_all():
+            if string.value in msg.raw_text and not string.retired:
+                return db.blacklists.string.hex_type, string.index
 
     if msg.file:
         # avoid a DoS when getting large files

--- a/kantek/plugins/private/template.py
+++ b/kantek/plugins/private/template.py
@@ -25,7 +25,7 @@ async def template(args, db: Database, event, msg: Message) -> Optional[MDTeXDoc
     if _template:
         await msg.edit(_template.content)
     else:
-        await event.delete
+        await event.delete()
 
 
 @template.subcommand()

--- a/migrations/20200802190944_chat-permissions/up.sql
+++ b/migrations/20200802190944_chat-permissions/up.sql
@@ -1,2 +1,2 @@
-ALTER TABLE chats ADD COLUMN permissions jsonb;
-ALTER TABLE chats ADD COLUMN locked bool DEFAULT FALSE;
+ALTER TABLE chats ADD COLUMN IF NOT EXISTS permissions jsonb;
+ALTER TABLE chats ADD COLUMN IF NOT EXISTS locked bool DEFAULT FALSE;


### PR DESCRIPTION
This PR includes fixes for the following errors:

.t not deleting the message if an unknown template was called
migrant failing due to an existing Column
Unhandled Exception on an update without raw_text